### PR TITLE
CI: Add !docker path filters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
     - '**'
     - '!**.yml'
     - '!docs/**'
+    - '!docker/**'
     - '!**.md'
     - '**/build.yml'
   pull_request:
@@ -18,6 +19,7 @@ on:
     - '**'
     - '!**.yml'
     - '!docs/**'
+    - '!docker/**'    
     - '!**.md'
     - '**/build.yml'
 


### PR DESCRIPTION
This should prevent the CI from triggering when ONLY files in /docker have been added or modified.

I'm hoping that https://github.com/actions/runner/issues/1182 will make maintenance a *little* easier in the future.