### PR TITLE
Fix path resolver and add debugging output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,9 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh 19 # install clang-19
       - name: Configure and build
-        run: scripts/build-default.sh
+        run: |
+          scripts/build-default.sh
+          bun run test
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4
         if: failure()
@@ -96,7 +98,9 @@ jobs:
           echo "PATH=$PATH" >> $GITHUB_ENV
 
       - name: Configure and build
-        run: scripts/build-default.sh
+        run: |
+          scripts/build-default.sh
+          bun run test
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4
         if: failure()

--- a/src/utils/paths.cpp
+++ b/src/utils/paths.cpp
@@ -56,11 +56,20 @@ std::pair<bool, std::string> resolve_path::normalizer(const char *parent, const 
     memset(ret+parent_len,0,child_len+1);
     memcpy(ret,parent,parent_len);
     int ptr = parent_len;
-    
+
     for(int j=0; j<child_len; ){
         if(tkn(child+j,"../")){
             //Go back to the past /
             if(ptr<=1)return {false, ""}; //Early failure, cannot track back.
+            if (j > 0) {
+                if (child[j-1] != '/') {
+                    uint8_t i = 0;
+                    for(;i<=sizeof "../";i++) {
+                        ret[ptr++] = child[j++];
+                    }
+                    continue;
+                }
+            }
             ptr-=2;
             for(;ret[ptr]!='/';ptr--);
             j+=3;
@@ -72,23 +81,16 @@ std::pair<bool, std::string> resolve_path::normalizer(const char *parent, const 
             j+=2;   //Just skip this.
             continue;
         }
-        else if(child[j]=='/' && child[j+1]=='/'){
+        else if(child[j]=='/' && j!=child_len-1){
             j++;
-            continue;
-        }
-        else if(child[j]=='/'){
-            j++;
+            ret[ptr]='/';
+            ptr++;
         }
         else{
             ret[ptr]=child[j];
             ptr++;
             j++;
             continue;
-        }
-
-        if(j!=child_len){
-            ret[ptr]='/';
-            ptr++;
         }
     }
 

--- a/test/marginal/resolver-paths.cpp
+++ b/test/marginal/resolver-paths.cpp
@@ -6,10 +6,10 @@ using namespace vs;
 
 int test_normalizer(const char* expected, const char* parent, const char* child, bool allow_exit, bool base_dir){
     auto tmp = resolve_path::normalizer(parent,child,allow_exit,base_dir);
-    std::cout<<"╭<parent> "<<parent<<"\n";
-    std::cout<<"├<child>  "<<child<<"\n";
-    std::cout<<"├>        "<<tmp.second<<"\n";
-    std::cout<<"╰>>       "<<expected<<"\n";
+    std::cerr<<"╭<parent> "<<parent<<"\n";
+    std::cerr<<"├<child>  "<<child<<"\n";
+    std::cerr<<"├>        "<<tmp.second<<"\n";
+    std::cerr<<"╰>>       "<<expected<<"\n";
     //if(!tmp.first)return 1;
     if(tmp.second==expected){return 0;}
     else{
@@ -26,10 +26,11 @@ int main(){
     ret+=test_normalizer("/quick-js/ww/a", "/hello world/banana/", "./../.././quick-js/ww/a", true, false);
     ret+=test_normalizer("", "/hello world/banana/", "../../quick-js/ww/a", false, false);
     ret+=test_normalizer("", "/hello world/banana/", "./../.././quick-js/ww/a", false, false);
-    ret+=test_normalizer("/hello world/banana/ww/a", "/hello world/banana/", "quick-js/../quick-js/ww/a", false, false);
+    ret+=test_normalizer("/hello world/banana/quick-js/ww/a", "/hello world/banana/", "quick-js/../quick-js/ww/a", false, false);
     ret+=test_normalizer("/hello world/banana/ww/a", "/hello world/banana/", "quick-js/./.././ww/a", false, false);
     ret+=test_normalizer("/a/b../", "/a/", "b../", false, false);
 
-    assert(ret=0);
+    std::cerr<<"ret = "<<ret<<"\n";
+    assert(ret==0);
     return 0;
 }


### PR DESCRIPTION
I don't know much about your preferences or how you like to configure tests, but I took a guess and made a few quick changes.

With the changes in this PR, when `meson test` is run with `-v`, one can see more:

```
stderr:
╭<parent> /hello world/banana/
├<child>  quick-js/././ww/aee/
├>        /hello world/banana/quick-js/ww/aee
╰>>       /hello world/banana/quick-js/ww/aee/
╭<parent> /hello world/banana/
├<child>  quick-js/././ww/aee/
├>        /hello world/banana/quick-js/ww/
╰>>       /hello world/banana/quick-js/ww/aee/
╭<parent> /hello world/banana/
├<child>  quick-js/././ww/aee
├>        /hello world/banana/quick-js/ww/
╰>>       /hello world/banana/quick-js/ww/
╭<parent> /hello world/banana/
├<child>  ../../quick-js/ww/a
├>        /quick-js/ww/a
╰>>       /quick-js/ww/a
╭<parent> /hello world/banana/
├<child>  ./../.././quick-js/ww/a
├>        /quick-js/ww/a
╰>>       /quick-js/ww/a
╭<parent> /hello world/banana/
├<child>  ../../quick-js/ww/a
├>
╰>>
╭<parent> /hello world/banana/
├<child>  ./../.././quick-js/ww/a
├>
╰>>
╭<parent> /hello world/banana/
├<child>  quick-js/../quick-js/ww/a
├>        /hello world/banana/quick-js/ww/a
╰>>       /hello world/banana/ww/a
╭<parent> /hello world/banana/
├<child>  quick-js/./.././ww/a
├>        /hello world/banana/ww/a
╰>>       /hello world/banana/ww/a
╭<parent> /a/
├<child>  b../
├>        /a/
╰>>       /a/b../
ret: 4
test_resolver-paths: ../test/marginal/resolver-paths.cpp:33: int main():
Assertion `ret=0' failed.
```