### PR TITLE
Testing xquartz to support x11 on macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,4 +102,9 @@ jobs:
         bun run codegen
         meson setup --reconfigure build/ --buildtype=release --native-file toolchains/flatpak.ini
         meson compile -C build/ vs:executable
-
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: logs
+        path: |
+          build/meson-logs/**/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,7 @@ jobs:
           libpng \
           meson \
           ninja
+        brew install --cask xquartz
         cd /opt/homebrew/opt/llvm/bin
         #ln -s clang++ clang++-19
         PATH=/opt/homebrew/opt/llvm/bin:$PATH


### PR DESCRIPTION
Attempt using xquartz to provide x11 support in macos.
- [x] Fix hashlib to support the right `endian.h`
- [ ] Macro collision in md4c, overriding one provided in xcode headers (just a warning)
- [x] ~~And now some random issues popping up as mushrooms I don't quite understand.~~ caused by VERSION in tcc. Left for investigation after https://github.com/KaruroChori/vs-fltk/pull/34 has been merged.
