### PR TITLE
Testing no x11 for macos on newer head

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -30,7 +30,6 @@ opt_fltk.add_cmake_defines(
         'FLTK_BUILD_TEST': false,
         'FLTK_BUILD_OPTIONS': false,
         'FLTK_BUILD_SHARED_LIBS': true,
-        'FLTK_BACKEND_X11': true,
         'CMAKE_POSITION_INDEPENDENT_CODE': true,
     },
 )


### PR DESCRIPTION
To verify if issues have changed since https://github.com/KaruroChori/vs-fltk/pull/32

Edit: the answer is no, same strange behaviour like before.