### PR TITLE
CI: No install cmake with pip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,31 +41,24 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          if [ "${{ contains(matrix.os, 'ubuntu') }}" = "true" ]; then
-            sudo apt update
-            curl -fsSL https://bun.sh/install | bash
-            echo "PATH=$HOME/.bun/bin:$PATH" >> $GITHUB_ENV
-            sudo apt update
-            sudo apt remove -y firefox
-            sudo apt upgrade -y
-            sudo apt install -y \
-              freeglut3-dev \
-              libcurl4-openssl-dev \
-              libpng-dev \
-              libsqlite3-0 \
-              python3-pip \
-              python3-setuptools
-            python3 -m pip install meson ninja
-            # for clang
-            sudo apt install -y wget gpg gnupg software-properties-common
-            curl -LO https://apt.llvm.org/llvm.sh
-            chmod +x llvm.sh
-            sudo ./llvm.sh 19 # install clang-19
-          else
-            brew update
-            brew install meson ninja
-          fi
-
+          curl -fsSL https://bun.sh/install | bash
+          echo "PATH=$HOME/.bun/bin:$PATH" >> $GITHUB_ENV
+          sudo apt update
+          sudo apt remove -y firefox
+          sudo apt upgrade -y
+          sudo apt install -y \
+            freeglut3-dev \
+            libcurl4-openssl-dev \
+            libpng-dev \
+            libsqlite3-0 \
+            python3-pip \
+            python3-setuptools
+          python3 -m pip install meson ninja
+          # for clang
+          sudo apt install -y wget gpg gnupg software-properties-common
+          curl -LO https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 19 # install clang-19
       - name: Configure and build
         run: |
           cmake --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,8 +56,6 @@ jobs:
               python3-pip \
               python3-setuptools
             python3 -m pip install meson ninja
-            python3 -m pip uninstall cmake
-            python3 -m pip install cmake==3.30.5 # workaround https://github.com/mesonbuild/meson/issues/13888
             # for clang
             sudo apt install -y wget gpg gnupg software-properties-common
             curl -LO https://apt.llvm.org/llvm.sh


### PR DESCRIPTION
https://github.com/mesonbuild/meson/issues/13888#issuecomment-2523746037

This can be merged after the runner has cmake 3.31.2

Current cmake version in runner shown on
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md