### PR TITLE
docker: Add VS_COMMONS_DIR, set bash as default shell

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN \
         unzip \
         wget
 
-RUN useradd -m builder && passwd -d builder
+RUN useradd -m builder -s /bin/bash && passwd -d builder
 RUN echo "builder ALL=(ALL) ALL" >> /etc/sudoers
 WORKDIR /home/builder
 USER builder

--- a/docker/entry-build.sh
+++ b/docker/entry-build.sh
@@ -3,10 +3,11 @@
 set -e
 $WORKSPACE/docker/entry-common.sh
 
-su builder -c ". ~/.profile && bash -c '\
-  cd $WORKSPACE && \
-  bun install &&
-  bun run codegen &&
-  bun run meson-setup.clang-release &&
+su builder -c bash << EOF
+  set -e
+  . ~/.profile
+  bun install
+  bun run codegen
+  bun run meson-setup.clang-release
   meson compile -C build/ vs:executable
-  '"
+EOF

--- a/docker/entry-common.sh
+++ b/docker/entry-common.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# main_entry.sh
+# entry-common.sh
 
 set -e
 
@@ -15,3 +15,6 @@ fi
 
 usermod -u $HOSTUID builder
 groupmod -g $HOSTGID builder
+
+echo 'export VS_COMMONS_DIR="$WORKSPACE"/build/commons/' >> /home/builder/.profile
+echo 'export VS_LOG_LEVEL=debug' >> /home/builder/.profile

--- a/docker/entry-default.sh
+++ b/docker/entry-default.sh
@@ -3,4 +3,4 @@
 set -e
 $WORKSPACE/docker/entry-common.sh
 
-su builder -c "cd $WORKSPACE && . ~/.profile && bash"
+su -l builder

--- a/meson.build
+++ b/meson.build
@@ -12,11 +12,6 @@ cxx = meson.get_compiler('cpp')
 #Used by pugi to enable compact mode. I might want to disable execptions too.
 add_global_arguments(['-DPUGIXML_COMPACT'], language: ['cpp', 'c'])
 
-meson.add_devenv(
-    {
-        'VS_COMMONS_DIR': join_paths(meson.project_source_root(), 'build', 'commons'),
-    },
-)
 meson.add_devenv({'VS_LOG_LEVEL': 'debug'})
 #TODO: Add a custom profile to devenv to avoid "polluting" or making user's one invalid.
 


### PR DESCRIPTION
Related to #47

This sets the default shell for 'builder' to '/bin/bash'.

When using 'meson devenv', the prompt becomes "[vs-fltk] builder@0884a9be3841:/vs-workspace/build$" instead of "?" now.

Although that doesn't really improve anything except cli editing, as I've moved the variables to the entrypoint scripts, and therefore devenv isn't needed if using the docker container.

This also fixes this annoying message when starting the container:

bash: cannot set terminal process group (14): Inappropriate ioctl for device
bash: no job control in this shell
builder@b7d17feb7490:~$