### PR TITLE
docker: Remove unneeded packages from install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,6 @@ RUN \
     apt install -y curl && \
     curl -s https://archive.swiftlang.xyz/install.sh | bash && \
     apt install -y \
-        build-essential \
         ca-certificates \
         clang-19 \
         cmake \
@@ -17,9 +16,6 @@ RUN \
         libcurl4-openssl-dev \
         libpango1.0-dev \
         libpng-dev \
-        libsqlite3-0 \
-        libsqlitecpp-dev \
-        libtcc-dev \
         lsb-release \
         meson \
         pkg-config \
@@ -29,7 +25,7 @@ RUN \
         wget
 
 RUN useradd -m builder -s /bin/bash && passwd -d builder
-RUN echo "builder ALL=(ALL) ALL" >> /etc/sudoers
+RUN echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 WORKDIR /home/builder
 USER builder
 


### PR DESCRIPTION
I *thought* this might bring down the image size a little, but it's still about 3.83GB

Based on your comment in
https://github.com/KaruroChori/vs-fltk/pull/39#issuecomment-2517856650 I thought it would be ok to remove sqlite?