### PR TITLE
docs: Add Build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Have you ever woken up in the middle of the night, thinking:
 Well, you should eat lighter before nighttime.  
 Still, it is your lucky day, & this project might be for you!
 
+[![Building-Testing-badge]][Building-Testing-url]
+
 ## What is VS (naming review pending)
 
 VS is a front-end framework based on the concept of composable SFCs (Single File Components).  
@@ -180,3 +182,7 @@ This project is based on the following dependencies:
 - [treesitter](https://tree-sitter.github.io/tree-sitter/) to handle parsing of languages (used for some components and the self-hosted editor).
 - [md4c](https://github.com/mity/md4c) a library to parse markdown (not just to HTML).
 - [nlohmann-json](https://github.com/nlohmann/json) to parse json in some `data` directives
+
+[Building-Testing-badge]: https://github.com/KaruroChori/vs-fltk/actions/workflows/build.yml/badge.svg?branch=master
+[Building-Testing-url]: https://github.com/KaruroChori/vs-fltk/actions/workflows/build.yml
+


### PR DESCRIPTION
This doesn't show up correctly in a preview:

![image](https://github.com/user-attachments/assets/6811cb09-4595-4d89-a399-9e7a9de0298e)

But I'm using essentially the same code at https://github.com/theimpossibleastronaut/rmw/blob/29be738076eab54ce624ee7b916d29379c74213c/README.md?plain=1#L13 and there's no problem.